### PR TITLE
fix: change default model to GPT-4.1-nano for cost reduction

### DIFF
--- a/lib/classify.ts
+++ b/lib/classify.ts
@@ -11,7 +11,7 @@ new VertexAI({authOptions: JSON.parse(process.env.GOOGLE_VERTEX_AI_WEB_CREDENTIA
 let model: BaseChatModel | null = null;
 
 async function getModel(modelName?: ChatModels) {
-  const selectedModel = modelName || ChatModels.OPENAI_GPT_4_1_MINI;
+  const selectedModel = modelName || ChatModels.OPENAI_GPT_4_1_NANO;
   
   // Always create a new model instance if a specific model is requested
   if (modelName || !model) {
@@ -113,7 +113,7 @@ Respond with only the JSON array, no additional text.
 export async function getLLMResponse(
   ctxWindow: string,
   systemMessage: string,
-  modelName: ChatModels = ChatModels.OPENAI_GPT_4_1_MINI,
+  modelName: ChatModels = ChatModels.OPENAI_GPT_4_1_NANO,
 ): Promise<any> { // eslint-disable-line @typescript-eslint/no-explicit-any
   const messages = [
     { role: "system", content: systemMessage },
@@ -129,7 +129,7 @@ export async function getLLMResponse(
 export async function getLLMResponseStream(
   ctxWindow: string,
   systemMessage: string,
-  modelName: ChatModels = ChatModels.OPENAI_GPT_4_1_MINI,
+  modelName: ChatModels = ChatModels.OPENAI_GPT_4_1_NANO,
 ) {
   const messages = [
     { role: "system", content: systemMessage },
@@ -145,7 +145,7 @@ export async function getLLMResponseStream(
 export async function agentLoop(
   query: string, 
   state: ThreadState,
-  model: ChatModels = ChatModels.OPENAI_GPT_4_1_MINI,
+  model: ChatModels = ChatModels.OPENAI_GPT_4_1_NANO,
 ) {
   // Tool execution - classify all tools from the input at once
   const toolIntents = await classifyIntent(query, model.toString());


### PR DESCRIPTION
Changes the default AI model from GPT-4.1-mini to GPT-4.1-nano to reduce API costs on the demo app.

## Changes
- Updated `lib/classify.ts` to use `OPENAI_GPT_4_1_NANO` as default
- Modified all functions that had GPT-4.1-mini as default parameter

Resolves #28

Generated with [Claude Code](https://claude.ai/code)